### PR TITLE
fix CI: upgrade npm for OIDC trusted publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [20.x]
+        node-version: [22.x]
 
     steps:
     - name: Checkout repository

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,7 +27,9 @@ jobs:
         with:
           node-version: 22
           cache: 'npm'
-          registry-url: 'https://registry.npmjs.org'
+
+      - name: Upgrade npm for OIDC trusted publishing
+        run: npm install -g npm@latest
 
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
## Summary
- **publish.yml**: Remove `registry-url` from setup-node (its `.npmrc` with empty `NODE_AUTH_TOKEN` blocks OIDC auth) and add `npm install -g npm@latest` to get npm 11.5.1+ (required for OIDC trusted publishing)
- **ci.yml**: Bump Node matrix from 20.x to 22.x to match publish workflow

## Context
The publish workflow has never successfully published — all 14 runs failed with `E404 Not Found` from npm. Root cause: Node 22 ships with npm 10.9.7, but OIDC trusted publishing requires npm 11.5.1+. Additionally, `setup-node` with `registry-url` writes an `.npmrc` that interferes with OIDC auth.

## Test plan
- [ ] CI passes on this PR (Node 22.x, lint, test, build, verify outputs)
- [ ] After merge, trigger `publish.yml` via workflow_dispatch and verify npm publish succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)