### PR TITLE
publish.yml: use Node 24 for native npm 11 OIDC support

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,14 +22,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Use Node.js 22
+      - name: Use Node.js 24 (ships with npm 11+ for OIDC publishing)
         uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
           cache: 'npm'
-
-      - name: Upgrade npm for OIDC trusted publishing
-        run: npm install -g npm@latest
 
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
## Summary
- Switch publish workflow from Node 22 to Node 24, which ships with npm 11.x natively
- Remove the `npm install -g npm@latest` workaround (breaks on Node 22 due to module resolution changes)

## Context
npm OIDC trusted publishing requires npm >=11.5.1. Node 22 ships with npm 10.x, and `npm install -g npm@latest` fails with `Cannot find module 'promise-retry'` on Node 22. Node 24 ships with npm 11.x out of the box, so no workaround is needed.

## Test plan
- [ ] CI passes (unchanged, still Node 22.x)
- [ ] After merge, publish workflow runs with Node 24 and npm 11.x
- [ ] npm publish succeeds via OIDC

🤖 Generated with [Claude Code](https://claude.com/claude-code)